### PR TITLE
Add installation instructions for homebrew and source

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,14 @@
+## Installation from Package
+
+### Mac OS X
+
+The Pony compiler (ponyc) is available for install using Homebrew!
+
+```bash
+brew update
+brew install ponyc
+```
+
+## Installation from Source
+
+Instructions for installing Pony from source on Windows, Mac OS X, Linux, and FreeBSD can be found in the [installation instructions in the Pony tutorial.]( http://tutorial.ponylang.org/getting-started/installation.html)


### PR DESCRIPTION
This adds a docs folder and adds an INSTALLATION.md file containing installation instructions for the Pony compiler using Homebrew as well as a link to instructions in the Pony tutorial to build ponyc from source on Windows, Mac OS X, Linux, and FreeBSD.