### PR TITLE
Make exercises compatible with pony 0.10.0

### DIFF
--- a/exercises/hamming/test.pony
+++ b/exercises/hamming/test.pony
@@ -36,5 +36,5 @@ class iso _HammingDistanceTest is UnitTest
   fun name(): String => "hamming/Hamming"
 
   fun apply(h: TestHelper) =>
-    h.assert_error(lambda()? => Hamming("GAT", "GA") end)
-    h.assert_error(lambda()? => Hamming("GA", "GAC") end)
+    h.assert_error({()? => Hamming("GAT", "GA")})
+    h.assert_error({()? => Hamming("GA", "GAC")})


### PR DESCRIPTION
The only thing that needed modification for the most recent release of pony was the syntax for lambda expressions.