### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,12 +3,6 @@
   "language": "Pony",
   "repository": "https://github.com/exercism/xpony",
   "active": false,
-  "ignored": [
-    "bin",
-    "docs",
-    "img",
-    "ponyc"
-  ],
   "exercises": [
     {
       "slug": "hello-world",


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.